### PR TITLE
Fix Flask app routes and add minimal templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,10 +17,6 @@ def realizados():
     pagos = Pago.query.filter(Pago.fecha_pagado.isnot(None)).all()
     return render_template("realizados.html", pagos=pagos)
 
-@app.route("/")
-def pendientes():
-    return "✅ ¡Funciona la ruta raíz!"
-
 @app.route("/pagar/<int:id>")
 def pagar(id):
     pago = Pago.query.get_or_404(id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,3 @@ MarkupSafe==3.0.2
 SQLAlchemy==2.0.41
 typing_extensions==4.14.0
 Werkzeug==3.1.3
-Flask
-Flask-SQLAlchemy

--- a/templates/comisiones.html
+++ b/templates/comisiones.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Comisiones</title>
+</head>
+<body>
+    <h1>Comisiones por persona</h1>
+    <ul>
+    {% for nombre, total in resumen %}
+        <li>{{ nombre }} - {{ total }}</li>
+    {% else %}
+        <li>No hay comisiones.</li>
+    {% endfor %}
+    </ul>
+    <a href="{{ url_for('pendientes') }}">Volver a pendientes</a>
+</body>
+</html>

--- a/templates/pendientes.html
+++ b/templates/pendientes.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Pagos pendientes</title>
+</head>
+<body>
+    <h1>Pagos pendientes</h1>
+    <ul>
+    {% for pago in pagos %}
+        <li>{{ pago.cliente }} - {{ pago.monto }} - <a href="{{ url_for('pagar', id=pago.id) }}">Marcar pagado</a></li>
+    {% else %}
+        <li>No hay pagos pendientes.</li>
+    {% endfor %}
+    </ul>
+    <a href="{{ url_for('realizados') }}">Ver realizados</a>
+</body>
+</html>

--- a/templates/realizados.html
+++ b/templates/realizados.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Pagos realizados</title>
+</head>
+<body>
+    <h1>Pagos realizados</h1>
+    <ul>
+    {% for pago in pagos %}
+        <li>{{ pago.cliente }} - {{ pago.monto }} (Pagado {{ pago.fecha_pagado }})</li>
+    {% else %}
+        <li>No hay pagos realizados.</li>
+    {% endfor %}
+    </ul>
+    <a href="{{ url_for('pendientes') }}">Ver pendientes</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- fix duplicate Flask route
- clean up requirements.txt
- add basic templates required by app

## Testing
- `python3 -m py_compile app.py models.py`
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845170477748333bf56d09422524c4a